### PR TITLE
Use ant-javacard for an easier and more flexible build change experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,18 +161,17 @@ resource consumption by tweaking the following variables:
 
 
 ## Building the CAP file
-- Copy the `javacard.properties.example` file to a file named
-  `javacard.properties`;
 
-- Edit the `javacard.properties` file and set the path of your
-  JavaCard Development Kit;
+- Set path to the JavaCard Development Kit:
+  `export JC_HOME="your/path/to/javacardkit"`
 
 - (Optional) Edit the `build.xml` file and replace the `0xAF:0xAF`
   bytes in the `APPLET_AID` with your own manufacturer identifier (see
-  section 4.2.1 of OpenPGP card specification);
+  section 4.2.1 of OpenPGP card specification). Alternatively, set the
+  right AID instance bytes during applet installation.
 
 - Execute `ant` with no parameter will produce the CAP file in
-  `build/fr/anssi/smartpgp/javacard/smartpgp.cap`.
+  `SmartPGPApplet.cap`.
 
 ## Building the CAP file with Gradle
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ relying on Global Platform with default keys are supported by
 [GlobalPlatformPro](https://github.com/martinpaljak/GlobalPlatformPro).
 
 Be careful to use a valid AID according to the OpenPGP card
-specification (see section 4.2.1) for each card.
+specification (see section 4.2.1) for each card (`-create <AID>` with
+GlobalPlatformPro)
 
 
 

--- a/build.xml
+++ b/build.xml
@@ -1,39 +1,13 @@
 <?xml version="1.0"?>
 <project name="smartpgp" default="convert" basedir=".">
   <description>Ant build for SmartPGP applet</description>
-  <property name="src" location="src"/>
-  <property name="build" location="build"/>
-  <property file="javacard.properties"/>
-  <property name="JAVA_PACKAGE" value="fr.anssi.smartpgp"/>
-  <property name="JAVA_PACKAGE_DIR" value="fr/anssi/smartpgp/"/>
-  <property name="APPLET_NAME" value="SmartPGPApplet"/>
-  <property name="PACKAGE_AID" value="0xd2:0x76:0x00:0x01:0x24:0x01"/>
-  <property name="APPLET_AID" value="0xd2:0x76:0x00:0x01:0x24:0x01:0x03:0x03:0xAF:0xAF:0x00:0x00:0x00:0x00:0x00:0x00"/>
-  <property name="VERSION" value="1.0"/>
-  <target name="init">
-    <mkdir dir="${build}"/>
-  </target>
-  <target name="compile" depends="init" description="compile the source">
-    <javac srcdir="${src}" destdir="${build}" includeantruntime="false" source="1.6" target="1.6">
-      <classpath>
-            <pathelement path="${JAVACARD_HOME}/lib/api_classic.jar"/>
-      </classpath>
-    </javac>
-  </target>
-  <target depends="compile" name="convert" description="convert to .cap">
-      <java classname="com.sun.javacard.converter.Main" fork="true" failonerror="true">
-      <arg line="-classdir ${build}"/>
-      <arg line="-verbose"/>
-      <arg line="-exportpath ${JAVACARD_HOME}/api_export_files"/>
-      <arg line="-out CAP JCA EXP"/>
-      <arg line="-applet ${APPLET_AID} ${APPLET_NAME}"/>
-      <arg line="${JAVA_PACKAGE} ${PACKAGE_AID} ${VERSION}"/>
-      <classpath>
-            <pathelement location="${JAVACARD_HOME}/lib/tools.jar"/>
-      </classpath>
-    </java>
-  </target>
-  <target name="clean" description="clean up">
-    <delete dir="${build}"/>
+  <get src="https://github.com/martinpaljak/ant-javacard/releases/download/18.06.25/ant-javacard.jar" dest="." skipexisting="true"/>
+  <taskdef name="javacard" classname="pro.javacard.ant.JavaCard" classpath="ant-javacard.jar"/>
+  <target name="convert">
+    <javacard>
+      <cap output="SmartPGPApplet.cap" sources="src" aid="d27600012401" version="1.0">
+        <applet class="fr.anssi.smartpgp.SmartPGPApplet" aid="d276000124010303AFAF000000000000"/>
+      </cap>
+    </javacard>
   </target>
 </project>

--- a/javacard.properties.example
+++ b/javacard.properties.example
@@ -1,1 +1,0 @@
-JAVACARD_HOME=path_to_your_jdk_3_0_4

--- a/src/fr/anssi/smartpgp/SmartPGPApplet.java
+++ b/src/fr/anssi/smartpgp/SmartPGPApplet.java
@@ -1313,6 +1313,7 @@ public final class SmartPGPApplet extends Applet {
         data.isTerminated = true;
     }
 
+    @SuppressWarnings("fallthrough")
     private final void processActivateFile(final byte p1, final byte p2) {
         if(p1 != (byte)0) {
             ISOException.throwIt(ISO7816.SW_WRONG_P1P2);


### PR DESCRIPTION
And suppress a warning from intentional code.